### PR TITLE
增加poi移除时的通知调用

### DIFF
--- a/BossLiveMapMod/ModBehaviour.cs
+++ b/BossLiveMapMod/ModBehaviour.cs
@@ -452,6 +452,10 @@ namespace BossLiveMapMod
         {
             foreach (var marker in _markers.Values)
             {
+                if(marker.Poi != null)
+                {
+                    PointsOfInterests.Unregister(marker.Poi);
+                }
                 DestroySafely(marker?.MarkerObject);
             }
             _markers.Clear();
@@ -919,6 +923,10 @@ namespace BossLiveMapMod
                 // ignore removal errors
             }
 
+            if(entry.Poi != null)
+            {
+                PointsOfInterests.Unregister(entry.Poi);
+            }
             if (entry.MarkerObject != null)
             {
                 DestroySafely(entry.MarkerObject);


### PR DESCRIPTION
你好，我这边是第三人称mod的协作者，目前在排查一个小地图poi对象空指针

实际问题场景如下：
- 同时加载小地图mod（如第三人称mod里的小地图功能）
- 打开大地图，反复勾选增删poi图标后，关闭大地图
- 由于小地图实时存在的特性，使得之前注册到小地图的poi对象的target被销毁，但是小地图本身的poi对象并没被销毁
- 出现log如下：
<img width="1470" height="767" alt="a13c5da09216aa177db15e1dd7cc9ec0" src="https://github.com/user-attachments/assets/a71a67b8-26ec-49dc-a8d1-cd41f758133d" />

因此增加一个poi对象销毁时的通知调用，用于给类似实时小地图进行进一步处理